### PR TITLE
Automatic Release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,70 @@
+---
+
+image: docker:19.03.12
+
+services:
+  - docker:19.03.12-dind
+
+variables:
+    ASSET_NAME: metacall-tarball-linux-amd64.tar.gz
+    # GH_TOKEN - from settings/ci_cd variables
+    # GH_REPO - from settings/ci_cd variables
+
+stages:
+    - prep
+    - test
+    - publish
+
+build:
+  stage: prep
+  script:
+      # Build the base image
+      - docker build -t metacall/distributable -f Dockerfile .
+      # Install the additional channels and pull (can't be cached)
+      - docker run --privileged --name tmp metacall/distributable sh -c 'guix pull'
+      # Commit changes
+      - docker commit tmp metacall/distributable && docker rm -f tmp
+      # Build dependencies
+      - docker run -d --privileged --name tmp metacall/distributable /metacall/scripts/deps.sh
+      # Commit changes
+      - docker commit tmp metacall/distributable && docker rm -f tmp
+      # Build tarball
+      - docker run --rm -v $PWD/out:/metacall/pack --privileged metacall/distributable /metacall/scripts/build.sh
+  only:
+    - tags
+  artifacts:
+    paths:
+      - out/
+    expire_in: 3h
+
+test:
+  stage: test
+  script:
+    # Generate a unique id for invalidating the cache of test layers
+    - CACHE_INVALIDATE=$(date +%s)
+    - docker build --build-arg CACHE_INVALIDATE=${CACHE_INVALIDATE} -t metacall/distributable_test:cli -f tests/cli/Dockerfile .
+    - docker build --build-arg CACHE_INVALIDATE=${CACHE_INVALIDATE} -t metacall/distributable_test:c -f tests/c/Dockerfile .
+    - docker build --build-arg CACHE_INVALIDATE=${CACHE_INVALIDATE} -t metacall/distributable_test:python -f tests/python/Dockerfile .
+    - docker build --build-arg CACHE_INVALIDATE=${CACHE_INVALIDATE} -t metacall/distributable_test:node -f tests/node/Dockerfile .
+    - docker build --build-arg CACHE_INVALIDATE=${CACHE_INVALIDATE} -t metacall/distributable_test:typescript -f tests/typescript/Dockerfile .
+  only:
+    - tags
+  needs:
+    - job: build
+      artifacts: true
+
+publish-github:
+  stage: publish
+  script:
+    # Install requirements
+    - apk --no-cache add curl
+    # Upload to github
+    - sh tools/release.sh
+  only:
+    - tags
+  needs:
+    - job: build
+      artifacts: true
+    - job: test
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ COPY / /metacall/
 
 RUN chmod +x /metacall/scripts/build.sh \
 	&& chmod +x /metacall/scripts/deps.sh \
-	&& mkdir -p /metacall/pack
+	&& mkdir -p /metacall/pack \
+	&& mv /metacall/channels/channels.scm /root/.config/guix/channels.scm
 
 CMD ["sh"]

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,7 @@ pull:
 	@docker stop metacall_distributable 2> /dev/null || true
 	@docker rm metacall_distributable 2> /dev/null || true
 	# Install the additional channels and pull
-	@docker run --privileged --name metacall_distributable metacall/distributable sh -c ' \
-		mv /metacall/channels/channels.scm /root/.config/guix/channels.scm \
-		&& guix pull'
+	@docker run --privileged --name metacall_distributable metacall/distributable sh -c 'guix pull'
 	@docker commit metacall_distributable metacall/distributable
 	@docker rm -f metacall_distributable
 	@echo "Done"

--- a/README.md
+++ b/README.md
@@ -23,3 +23,10 @@ In order to update hash from MetaCall Core package, just run the following comma
 ```bash
 make download
 ```
+
+## GitLab CI settings
+make sure to increase the job timeout to 2h+ (build job takes about a litle over an hour)
+in order to publish the tarball on GitHub as auto release you need to define the following variables in GitLab CI/CD settings, variable submenu
+
+* `GH_TOKEN` - a GitHub access token (select repo scope)
+* `GH_REPO` - a GitHub repo in the format of **OWNER/REPO** e.g. `metacall/distributable`

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -19,4 +19,24 @@
 #	limitations under the License.
 #
 
-# TODO
+tag_url="https://api.github.com/repos/${GH_REPO}/releases/tags/${CI_COMMIT_TAG}"
+release_url="https://api.github.com/repos/${GH_REPO}/releases"
+token="Authorization: token ${GH_TOKEN}"
+
+# Create release
+# CI_COMMIT_TITLE as release name
+# CI_COMMIT_DESCRIPTION as release body
+payload=$(printf '{"tag_name": "%s","name": "%s","body": "%s","draft": %s,"prerelease": %s}' "${CI_COMMIT_TAG}" "${CI_COMMIT_TITLE}" "${CI_COMMIT_DESCRIPTION}" "false" "false" )
+api_response=$(curl -s -d "${payload}" -H "${token}" ${release_url})
+echo "${api_response}"
+
+# Get tag info
+tag_info=$(curl -sH ${token} ${tag_url})
+# Get release ID
+eval $(echo "${tag_info}" | grep -m 1 "id.:" | grep -w id | tr : = | tr -cd '[[:alnum:]]=')
+[ "${id}" ] || { echo "Error: Failed to get release id for tag: ${tag}"; echo "${tag_info}" | awk 'length($0)<100' >&2; exit 1; }
+# Upload asset
+upload_url="https://uploads.github.com/repos/${GH_REPO}/releases/${id}/assets?name=${ASSET_NAME}"
+upload_response=$(curl -s --data-binary @"${PWD}/out/tarball.tar.gz" -H "${token}" -H "Content-Type: application/octet-stream" ${upload_url})
+echo "${upload_response}"
+


### PR DESCRIPTION
Closes: #2 

this PR contains the following changes:

1. A refactoring of pull target; because that mv command was getting in the way of a CI job (random fails saying `mv command not found`) and since it was a static/mandatory step anyway, I see no harm in moving it to Dockerfile - https://github.com/metacall/distributable/commit/e9a34c023b720311dc179e3c367a0308658f53e6

2. Upon creating a new tag it will trigger the CI to prepare a tarball, creates a release by using `${CI_COMMIT_TITLE}` and `${CI_COMMIT_DESCRIPTION}` as name and body for the release. then uploads the build artifact as `metacall-tarball-linux-amd64.tar.gz` - https://github.com/metacall/distributable/commit/b24932947b1eabfa42a51427165953d3949f3254

3. README.md is updated with required steps for automatic release. https://github.com/metacall/distributable/commit/c5c38ce74e12970ca81e6b78f7f7c389ef3e4935

also, I tried my best to speed up the build process. but `guix pull` cannot be cached. hence it takes around 50-70 minutes to build. and most of the time is spent by `guix pull`. so be sure to increase the default timeout per job to 2h+

if you try to cache that step, it yields the following error:

```
FILE: scripts/build.sh
ice-9/eval.scm:223:20: In procedure proc:
error: libnode: unbound variable
hint: Did you forget a `use-modules' form?
```

you can find more information about GitLab CI predefined variables [here](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html). I'm not sure if commit title and commit description are smart enough to pickup the commit message of current tag.

[see the result](https://github.com/itshaadi/distributable/releases) - release body contains both commit title and commit description of the tag but it's name belongs to a previous commit on master (I didn't setup a mirror so that's why it doesn't match with any commit from this PR). 

you can always add a Changelog file and do a commit on it before creating a lightweight tag. this way you can ensure that release name and body are intentional and accurate.

also `.netrc.template` is not necessary because it's functionality is replaced by CI variables. you can decide to remove or integrate it in future.
